### PR TITLE
path-based pull request labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+actions: ".github/**"
+
+documentation: "**/*.md"
+
+systems: "src/lib/systems/**"
+
+components: "src/lib/components/**"
+
+keybindings: "src/lib/keybindings.rs"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: Labeler
+on: [pull_request_target]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,4 +11,5 @@ jobs:
     steps:
       - uses: actions/labeler@v4
         with:
+          dot: true
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Purpose

- pull requests should be labeled in order to easily filter and classify them
- this automates the process

## Changes

- added labeler workflow
- configured labeler workflow to apply labels based on the paths of filechanges in a given pull request
